### PR TITLE
change: 時刻から減速度を自動計算する関数群の追加

### DIFF
--- a/Automatic9045.BveEx.ExtendedTrainScheduler/Automatic9045.BveEx.ExtendedTrainScheduler.csproj
+++ b/Automatic9045.BveEx.ExtendedTrainScheduler/Automatic9045.BveEx.ExtendedTrainScheduler.csproj
@@ -39,21 +39,17 @@
       <HintPath>..\packages\BveEx.CoreExtensions.2.0.0\lib\BveEx.CoreExtensions.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="BveEx.PluginHost, Version=2.0.41222.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BveEx.PluginHost.2.0.5\lib\BveEx.PluginHost.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="BveEx.PluginHost, Version=2.0.50204.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BveEx.PluginHost.2.0.5.1\lib\BveEx.PluginHost.dll</HintPath>
     </Reference>
-    <Reference Include="BveTypes, Version=2.0.50202.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BveEx.PluginHost.2.0.5\lib\BveTypes.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="BveTypes, Version=2.0.50204.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BveEx.PluginHost.2.0.5.1\lib\BveTypes.dll</HintPath>
     </Reference>
     <Reference Include="FastCaching, Version=2.0.41222.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BveEx.PluginHost.2.0.5\lib\FastCaching.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\BveEx.PluginHost.2.0.5.1\lib\FastCaching.dll</HintPath>
     </Reference>
     <Reference Include="FastMember, Version=2.0.41222.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BveEx.PluginHost.2.0.5\lib\FastMember.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\BveEx.PluginHost.2.0.5.1\lib\FastMember.dll</HintPath>
     </Reference>
     <Reference Include="ObjectiveHarmonyPatch, Version=1.2.50130.1, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ObjectiveHarmonyPatch.1.2.0\lib\ObjectiveHarmonyPatch.dll</HintPath>
@@ -72,9 +68,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="TypeWrapping, Version=2.0.41222.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BveEx.PluginHost.2.0.5\lib\TypeWrapping.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="TypeWrapping, Version=2.0.50204.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BveEx.PluginHost.2.0.5.1\lib\TypeWrapping.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Automatic9045.BveEx.ExtendedTrainScheduler/PluginMain.cs
+++ b/Automatic9045.BveEx.ExtendedTrainScheduler/PluginMain.cs
@@ -50,8 +50,8 @@ namespace Automatic9045.BveEx.ExtendedTrainScheduler
 
                     TrackOperator = TrackOperator.Create(statements.SetTrack, trainInfos, ThrowError);
                     PreTrainOperator = PreTrainOperator.Create(statements.AttachToTrain, statements.Detach, trainInfos, ThrowError);
-                    SpeedOperator = SpeedOperator.Create(statements.StopUntil, BveHacker.MapLoader.Map.TrainInfos, ThrowError);
-                    SpeedOverrider.Override(statements.AccelerateFromHere, statements.AccelerateToHere, BveHacker.MapLoader.Map.TrainInfos, ThrowError);
+                    SpeedOperator = SpeedOperator.Create(statements.StopUntil,statements.StopAtUntil, statements.StopAt, statements.AccelerateToHereAt,BveHacker.MapLoader.Map.TrainInfos, ThrowError);
+                    SpeedOverrider.Override(statements.AccelerateFromHere, statements.AccelerateToHere, BveHacker.MapLoader.Map.TrainInfos, ThrowError, ((Station)instance.Map.Stations[0]).DefaultTime);
 
                     AreOperatorsInitialized = true;
 

--- a/Automatic9045.BveEx.ExtendedTrainScheduler/Speed/SpeedOperator.cs
+++ b/Automatic9045.BveEx.ExtendedTrainScheduler/Speed/SpeedOperator.cs
@@ -13,20 +13,26 @@ namespace Automatic9045.BveEx.ExtendedTrainScheduler.Speed
     internal class SpeedOperator
     {
         private readonly IReadOnlyDictionary<TrainStopObject, TimeSpan> DepartureTimes;
+        private readonly IReadOnlyDictionary<TrainStopObject, TimeSpan>ArrivalTimes;
+        private readonly Dictionary<TrainStopObject, Statement>ToHereTimes;
         private readonly Action<string, string, int, int> OnError;
 
-        public SpeedOperator(IReadOnlyDictionary<TrainStopObject, TimeSpan> departureTimes, Action<string, string, int, int> onError)
+        public SpeedOperator(IReadOnlyDictionary<TrainStopObject, TimeSpan> departureTimes, IReadOnlyDictionary<TrainStopObject, TimeSpan> arrivalTimes,Dictionary<TrainStopObject, Statement> toHereStatement,Action<string, string, int, int> onError)
         {
             DepartureTimes = departureTimes;
+            ArrivalTimes = arrivalTimes;
+            ToHereTimes = toHereStatement;
             OnError = onError;
         }
 
-        public static SpeedOperator Create(IEnumerable<Statement> stopUntil,
+        public static SpeedOperator Create(IEnumerable<Statement> stopUntil,IEnumerable<Statement> stopAtUntil,IEnumerable<Statement> stopAt,IEnumerable<Statement> toHereAt,
             IReadOnlyDictionary<string, TrainInfo> trainInfos, Action<string, string, int, int> onError)
         {
             Validator validator = new Validator(onError);
 
             Dictionary<TrainStopObject, TimeSpan> departureTimes = new Dictionary<TrainStopObject, TimeSpan>();
+            Dictionary<TrainStopObject, TimeSpan> arrivalTimes = new Dictionary<TrainStopObject, TimeSpan>();
+            Dictionary<TrainStopObject, Statement> toHereTimes = new Dictionary<TrainStopObject, Statement>();
             foreach (Statement statement in stopUntil)
             {
                 MapStatement statementSource = statement.Source;
@@ -53,10 +59,85 @@ namespace Automatic9045.BveEx.ExtendedTrainScheduler.Speed
                     }
                 }
             }
+            foreach (Statement statement in stopAtUntil)
+            {
+                MapStatement statementSource = statement.Source;
 
-            return new SpeedOperator(departureTimes, onError);
+                validator.CheckClauseLength(statementSource, 6);
+
+                TrainInfo trainInfo = validator.GetTrain(statementSource, trainInfos).Info;
+                if (!(trainInfo is null))
+                {
+                    try
+                    {
+                        TimeSpan arrivalTime = CompatibleTimeSpanFactory.Parse(statementSource.Clauses[5].Args[0]);
+                        TimeSpan departureTime = CompatibleTimeSpanFactory.Parse(statementSource.Clauses[5].Args[1]);
+                        double acceleration = Convert.ToDouble(statementSource.Clauses[5].Args[2]) / 3.6;
+                        double speed = Convert.ToDouble(statementSource.Clauses[5].Args[3]) / 3.6;
+
+                        TrainStopObject stop = new TrainStopObject(statementSource.Location, 1, 1, acceleration, speed);
+                        trainInfo.Insert(stop);
+                        departureTimes[stop] = departureTime;
+                        arrivalTimes[stop] = arrivalTime;
+                    }
+                    catch (SyntaxException ex)
+                    {
+                        validator.ThrowError(ex.Message, statementSource);
+                    }
+                }
+            }
+            foreach (Statement statement in stopAt)
+            {
+                MapStatement statementSource = statement.Source;
+
+                validator.CheckClauseLength(statementSource, 6);
+
+                TrainInfo trainInfo = validator.GetTrain(statementSource, trainInfos).Info;
+                if (!(trainInfo is null))
+                {
+                    try
+                    {
+                        TimeSpan arrivalTime = CompatibleTimeSpanFactory.Parse(statementSource.Clauses[5].Args[0]);
+                        int stopTime = (int)(Convert.ToDouble(statementSource.Clauses[5].Args[1])*1000);
+                        double acceleration = Convert.ToDouble(statementSource.Clauses[5].Args[2]) / 3.6;
+                        double speed = Convert.ToDouble(statementSource.Clauses[5].Args[3]) / 3.6;
+
+                        TrainStopObject stop = new TrainStopObject(statementSource.Location, 1, stopTime, acceleration, speed);
+                        trainInfo.Insert(stop);
+                        arrivalTimes[stop] = arrivalTime;
+                    }
+                    catch (SyntaxException ex)
+                    {
+                        validator.ThrowError(ex.Message, statementSource);
+                    }
+                }
+            }
+            foreach (Statement statement in toHereAt)
+            {
+                MapStatement statementSource = statement.Source;
+
+                validator.CheckClauseLength(statementSource, 7);
+
+                TrainInfo trainInfo = validator.GetTrain(statementSource, trainInfos).Info;
+                if (!(trainInfo is null))
+                {
+                    try
+                    {
+                        double speed = Convert.ToDouble(statementSource.Clauses[6].Args[0]) / 3.6;
+                        TimeSpan toHereTime = CompatibleTimeSpanFactory.Parse(statementSource.Clauses[6].Args[1]);
+
+                        TrainStopObject stop = new TrainStopObject(statementSource.Location, 0, 0,0, speed);
+                        trainInfo.Insert(stop);
+                        toHereTimes[stop] = statement;
+                    }
+                    catch (SyntaxException ex)
+                    {
+                        validator.ThrowError(ex.Message, statementSource);
+                    }
+                }
+            }
+            return new SpeedOperator(departureTimes,arrivalTimes,toHereTimes, onError);
         }
-
         public IEnumerable<TrainSchedule> CompileToSchedules(TrainInfo trainInfo, TimeSpan originTime)
         {
             if (trainInfo.Count == 0) yield break;
@@ -68,62 +149,215 @@ namespace Automatic9045.BveEx.ExtendedTrainScheduler.Speed
                 TrainStopObject prev = (TrainStopObject)trainInfo[j];
                 TrainStopObject next = (TrainStopObject)trainInfo[j + trainInfo.Direction];
 
-                if (TimeSpan.Zero < prev.StopTime || i == 0)
+                if (ToHereTimes.TryGetValue(next, out Statement statement))
                 {
-                    yield return new TrainSchedule(time, TimeSpan.Zero, prev.Location, 0, 0);
-                    time += prev.StopTime;
-
-                    if (DepartureTimes.TryGetValue(prev, out TimeSpan departureTime))
-                    {
-                        if (trainInfo.EnableLocation != 0 || trainInfo.EnableTime != TimeSpan.Zero)
-                        {
-                            OnError("Train[trainKey].StopUntil ステートメントは Train[trainKey].Enable ステートメントと併用できません。", null, 0, 0);
-                        }
-                        else
-                        {
-                            if (time < departureTime) time = departureTime - originTime;
-                        }
-                    }
-                }
-
-                double prevAccelerationInv = 0 < prev.Acceleration ? 1 / prev.Acceleration : 0;
-                double nextDecelerationInv = 0 < next.Deceleration ? 1 / next.Deceleration : 0;
-
-                double finishAccelerateLocation = prev.Location + prev.Speed * prev.Speed * prevAccelerationInv / 2 * trainInfo.Direction;
-                double beginDecelerateLocation = next.Location - prev.Speed * prev.Speed * nextDecelerationInv / 2 * trainInfo.Direction;
-
-                bool needCoasting = finishAccelerateLocation * trainInfo.Direction < beginDecelerateLocation * trainInfo.Direction;
-                if (needCoasting)
-                {
-                    if (prevAccelerationInv != 0)
-                    {
-                        TimeSpan accelerateDuration = CompatibleTimeSpanFactory.FromSeconds(prev.Speed * prevAccelerationInv);
-                        yield return new TrainSchedule(time, time, prev.Location, 0, prev.Acceleration * trainInfo.Direction);
-                        time += accelerateDuration;
+                    if(statement is null) {
+                        continueFunc();
+                        continue;
                     }
 
-                    TimeSpan coastDuration = CompatibleTimeSpanFactory.FromSeconds((beginDecelerateLocation - finishAccelerateLocation) / prev.Speed * trainInfo.Direction);
-                    yield return new TrainSchedule(time, time, finishAccelerateLocation, prev.Speed * trainInfo.Direction, 0);
-                    time += coastDuration;
+                    Validator validator = new Validator(OnError);
 
-                    if (nextDecelerationInv != 0)
+            MapStatement statementSource = statement.Source;
+
+                    int direction = trainInfo.Direction;
+                    double initialLocation = statementSource.Location;
+
+                    TrainStopObject firstStop = new TrainStopObject(initialLocation, double.MaxValue, 0, double.MaxValue, 0);
+                    int firstIndex = InsertStop(firstStop);
+
+                    int prevIndex = firstIndex - direction;
+                    int nextIndex = firstIndex + direction;
+                    if (prevIndex < 0 || trainInfo.Count <= prevIndex || nextIndex < 0 || trainInfo.Count <= nextIndex)
                     {
-                        TimeSpan decelerateDuration = CompatibleTimeSpanFactory.FromSeconds(prev.Speed * nextDecelerationInv);
-                        yield return new TrainSchedule(time, time + decelerateDuration, next.Location, 0, -next.Deceleration * trainInfo.Direction);
-                        time += decelerateDuration;
+                        validator.ThrowError("このステートメントは 2 つの Train.Stop ステートメントの間に定義する必要があります。", statementSource);
+                        continueFunc();
+                        continue;
+                    }
+                    //TrainStopObject prevStop = (TrainStopObject)trainInfo[prevIndex];
+
+                    double initialSpeed = prev.Speed;
+                    double targetSpeed = Convert.ToDouble(statementSource.Clauses[6].Args[0]) / 3.6;
+
+                    double acceleration = 20;
+                    
+                    TimeSpan at=CompatibleTimeSpanFactory.Parse(statementSource.Clauses[6].Args[1]);
+                    
+                        double SL = initialLocation;
+                        double PL = prev.Location;
+                        double PS = initialSpeed;
+                    TimeSpan timeb =time+ TimeSpan.Zero;
+                    if (TimeSpan.Zero < prev.StopTime || i == 0)
+                    {
+                        timeb += prev.StopTime;
+
+                        if (DepartureTimes.TryGetValue(prev, out TimeSpan departureTime))
+                        {
+                            if (trainInfo.EnableLocation != 0 || trainInfo.EnableTime != TimeSpan.Zero)
+                            {
+                                OnError("Train[trainKey].StopUntil ステートメントは Train[trainKey].Enable ステートメントと併用できません。", null, 0, 0);
+                            }
+                            else
+                            {
+                                if (timeb < departureTime) timeb = departureTime - originTime;
+                            }
+                        }
+                    }
+                    double ac=prev.Acceleration;
+                    TimeSpan dt = timeb+originTime;
+                    double SP=targetSpeed;
+                    double pd=SP-PS;
+                    double LS = SL-PL;
+                    double tsl = PS*(at.TotalSeconds-dt.TotalSeconds-PS/(2*ac));
+                    double dectime=2*(LS-tsl)/(pd);
+                    double dc =pd/ dectime;
+                    acceleration=dc;/**/
+
+                    firstStop.Speed = initialSpeed;
+                    if (targetSpeed == initialSpeed)
+                    {
+                        continueFunc();
+                        continue;
+                    }
+
+                    int sign = Math.Sign(targetSpeed - initialSpeed);
+                    double signedStepSpeed = SpeedOverrider.StepSpeed * sign;
+
+                    if (Math.Sign(acceleration) != sign){
+                        validator.ThrowError($"時刻{dt}に距離程{SL}mを速度{Math.Abs(targetSpeed)*3.6}km/hで通過することは不可能です。", statementSource);
+                        continueFunc();
+                        continue;
+                    }
+
+                    double accelerateDistance = (targetSpeed - initialSpeed) * (targetSpeed + initialSpeed) / 2 / acceleration * direction;
+                    
+                        initialLocation -= accelerateDistance;
+                        firstStop.Location = initialLocation;
+                    
+
+                    double lastLocation = initialLocation + accelerateDistance;
+                    if (Math.Sign(prev.Location - lastLocation) != Math.Sign(firstStop.Location - lastLocation))
+                    {
+                        validator.ThrowError("他のステートメントの加減速と干渉します。距離を離してください。", statementSource);
+                        continueFunc();
+                        continue;
+                    }
+                    //*
+                    for (int k = 1; Math.Sign(initialSpeed + signedStepSpeed * k - targetSpeed) != sign; k++)
+                    {
+                        double location = initialLocation + signedStepSpeed / acceleration * k * (initialSpeed + signedStepSpeed / 2 * k) * direction;
+                        double stopAcceleration = k % 20 == 0 ? double.MaxValue : 0;
+                        TrainStopObject stop = new TrainStopObject(location, stopAcceleration, 0, stopAcceleration, initialSpeed + signedStepSpeed * k);
+                        trainInfo.Insert(stop);
+                    }
+                    /**/
+                    TrainStopObject lastStop2 = new TrainStopObject(lastLocation, double.MaxValue, 0, double.MaxValue, targetSpeed);
+                    trainInfo.Insert(lastStop2);
+
+                    continueFunc();
+                    continue;
+
+                    int InsertStop(TrainStopObject stop)
+                    {
+                        trainInfo.Insert(stop);
+                        return trainInfo.IndexOf(stop);
+                    }
+                    void continueFunc()
+                    {
+                        trainInfo.Remove(next);
+                        i= trainInfo.IndexOf(prev)-1;
+                        statement=null;
                     }
                 }
                 else
                 {
-                    float maxSpeed = (float)Math.Sqrt(2 * trainInfo.Direction * (next.Location - prev.Location) / (prevAccelerationInv + nextDecelerationInv));
+                    if (TimeSpan.Zero < prev.StopTime || i == 0)
+                    {
+                        yield return new TrainSchedule(time, TimeSpan.Zero, prev.Location, 0, 0);
+                        time += prev.StopTime;
 
-                    TimeSpan accelerateDuration = CompatibleTimeSpanFactory.FromSeconds(maxSpeed * prevAccelerationInv);
-                    yield return new TrainSchedule(time, time, prev.Location, 0, prev.Acceleration * trainInfo.Direction);
-                    time += accelerateDuration;
+                        if (DepartureTimes.TryGetValue(prev, out TimeSpan departureTime))
+                        {
+                            if (trainInfo.EnableLocation != 0 || trainInfo.EnableTime != TimeSpan.Zero)
+                            {
+                                OnError("Train[trainKey].StopUntil ステートメントは Train[trainKey].Enable ステートメントと併用できません。", null, 0, 0);
+                            }
+                            else
+                            {
+                                if (time < departureTime) time = departureTime - originTime;
+                            }
+                        }
+                    }
 
-                    TimeSpan decelerateDuration = CompatibleTimeSpanFactory.FromSeconds(maxSpeed * nextDecelerationInv);
-                    yield return new TrainSchedule(time, time + decelerateDuration, next.Location, 0, -next.Deceleration * trainInfo.Direction);
-                    time += decelerateDuration;
+                    double prevAccelerationInv = 0 < prev.Acceleration ? 1 / prev.Acceleration : 0;
+                    double nextDecelerationInv = 0 < next.Deceleration ? 1 / next.Deceleration : 0;
+
+                    if (ArrivalTimes.TryGetValue(next, out TimeSpan at))
+                    {
+                        TimeSpan dt = time+originTime;
+                        double NL = next.Location;
+                        double PL = prev.Location;
+                        double SP = prev.Speed;
+                        double ac = prev.Acceleration;
+                        double dc = -SP/((NL-PL)*trainInfo.Direction/SP+SP/2/ac-at.TotalSeconds+dt.TotalSeconds)/2;
+                        next.Deceleration=dc;
+                        nextDecelerationInv=1/dc;
+                        if (dc<0)
+                        {
+                            OnError($"列車の速度が低すぎるか加減速が干渉します. {dt}, {PL} to {at}, {NL}", null, 0, 0);
+                        }
+                    }
+
+                    double finishAccelerateLocation = prev.Location + prev.Speed * prev.Speed * prevAccelerationInv / 2 * trainInfo.Direction;
+                    double beginDecelerateLocation = next.Location - prev.Speed * prev.Speed * nextDecelerationInv / 2 * trainInfo.Direction;
+
+                    bool needCoasting = finishAccelerateLocation * trainInfo.Direction < beginDecelerateLocation * trainInfo.Direction;
+                    if (needCoasting)
+                    {
+                        if (prevAccelerationInv != 0)
+                        {
+                            TimeSpan accelerateDuration = CompatibleTimeSpanFactory.FromSeconds(prev.Speed * prevAccelerationInv);
+                            yield return new TrainSchedule(time, time, prev.Location, 0, prev.Acceleration * trainInfo.Direction);
+                            time += accelerateDuration;
+                        }
+
+                        TimeSpan coastDuration = CompatibleTimeSpanFactory.FromSeconds((beginDecelerateLocation - finishAccelerateLocation) / prev.Speed * trainInfo.Direction);
+                        yield return new TrainSchedule(time, time, finishAccelerateLocation, prev.Speed * trainInfo.Direction, 0);
+                        time += coastDuration;
+
+                        if (nextDecelerationInv != 0)
+                        {
+                            TimeSpan decelerateDuration = CompatibleTimeSpanFactory.FromSeconds(prev.Speed * nextDecelerationInv);
+                            yield return new TrainSchedule(time, time + decelerateDuration, next.Location, 0, -next.Deceleration * trainInfo.Direction);
+                            time += decelerateDuration;
+                        }
+                    }
+                    else if(finishAccelerateLocation * trainInfo.Direction > beginDecelerateLocation * trainInfo.Direction&&ArrivalTimes.TryGetValue(next, out at))
+                    {
+                        TimeSpan dt = time+originTime;
+                        double maxSpeed = 2 * trainInfo.Direction * (next.Location - prev.Location) /(at-dt).TotalSeconds;
+
+                        TimeSpan accelerateDuration = CompatibleTimeSpanFactory.FromSeconds(maxSpeed * prevAccelerationInv);
+                        yield return new TrainSchedule(time, time, prev.Location, 0, prev.Acceleration * trainInfo.Direction);
+                        time += accelerateDuration;
+
+                        TimeSpan decelerateDuration = at-dt-accelerateDuration;
+                        next.Deceleration=maxSpeed/decelerateDuration.TotalSeconds;
+                        yield return new TrainSchedule(time, time + decelerateDuration, next.Location, 0, -next.Deceleration * trainInfo.Direction);
+                        time += decelerateDuration;
+                    }
+                    else
+                    {
+                        float maxSpeed = (float)Math.Sqrt(2 * trainInfo.Direction * (next.Location - prev.Location) / (prevAccelerationInv + nextDecelerationInv));
+
+                        TimeSpan accelerateDuration = CompatibleTimeSpanFactory.FromSeconds(maxSpeed * prevAccelerationInv);
+                        yield return new TrainSchedule(time, time, prev.Location, 0, prev.Acceleration * trainInfo.Direction);
+                        time += accelerateDuration;
+
+                        TimeSpan decelerateDuration = CompatibleTimeSpanFactory.FromSeconds(maxSpeed * nextDecelerationInv);
+                        yield return new TrainSchedule(time, time + decelerateDuration, next.Location, 0, -next.Deceleration * trainInfo.Direction);
+                        time += decelerateDuration;
+                    }
                 }
             }
 

--- a/Automatic9045.BveEx.ExtendedTrainScheduler/StatementSet.cs
+++ b/Automatic9045.BveEx.ExtendedTrainScheduler/StatementSet.cs
@@ -11,6 +11,7 @@ namespace Automatic9045.BveEx.ExtendedTrainScheduler
     internal class StatementSet
     {
         private static readonly string UserName = "Automatic9045";
+        private static readonly string AdditionalUserName = "Toukaitetudou";
 
         private static readonly ClauseFilter Root = ClauseFilter.Element(nameof(ExtendedTrainScheduler), 0);
         private static readonly ClauseFilter Train = ClauseFilter.Element("Train", 1);
@@ -48,10 +49,10 @@ namespace Automatic9045.BveEx.ExtendedTrainScheduler
             IEnumerable<Statement> setTrack = source.FindUserStatements(UserName, Root, Train, ClauseFilter.Function("SetTrack", 1));
             IEnumerable<Statement> accelerateFromHere = source.FindUserStatements(UserName, Root, Train, Accelerate, ClauseFilter.Function("FromHere", 2));
             IEnumerable<Statement> accelerateToHere = source.FindUserStatements(UserName, Root, Train, Accelerate, ClauseFilter.Function("ToHere", 2));
-            IEnumerable<Statement> accelerateToHereAt = source.FindUserStatements(UserName, Root, Train, Accelerate, ClauseFilter.Function("ToHereAt", 2));
+            IEnumerable<Statement> accelerateToHereAt = source.FindUserStatements(AdditionalUserName, Root, Train, Accelerate, ClauseFilter.Function("ToHereAt", 2));
             IEnumerable<Statement> stopUntil = source.FindUserStatements(UserName, Root, Train, ClauseFilter.Function("StopUntil", 4));
-            IEnumerable<Statement> stopAtUntil = source.FindUserStatements(UserName, Root, Train, ClauseFilter.Function("StopAtUntil", 4));
-            IEnumerable<Statement> stopAt = source.FindUserStatements(UserName, Root, Train, ClauseFilter.Function("StopAt", 4));
+            IEnumerable<Statement> stopAtUntil = source.FindUserStatements(AdditionalUserName, Root, Train, ClauseFilter.Function("StopAtUntil", 4));
+            IEnumerable<Statement> stopAt = source.FindUserStatements(AdditionalUserName, Root, Train, ClauseFilter.Function("StopAt", 4));
             IEnumerable<Statement> attachToTrain = source.FindUserStatements(UserName, Root, PreTrain, ClauseFilter.Function("AttachToTrain", 1));
             IEnumerable<Statement> detach = source.FindUserStatements(UserName, Root, PreTrain, ClauseFilter.Function("Detach", 0));
 

--- a/Automatic9045.BveEx.ExtendedTrainScheduler/StatementSet.cs
+++ b/Automatic9045.BveEx.ExtendedTrainScheduler/StatementSet.cs
@@ -20,18 +20,25 @@ namespace Automatic9045.BveEx.ExtendedTrainScheduler
         public IEnumerable<Statement> SetTrack { get; }
         public IEnumerable<Statement> AccelerateFromHere { get; }
         public IEnumerable<Statement> AccelerateToHere { get; }
+        public IEnumerable<Statement> AccelerateToHereAt { get; }
         public IEnumerable<Statement> StopUntil { get; }
+        public IEnumerable<Statement> StopAtUntil { get; }
+        public IEnumerable<Statement> StopAt { get; }
         public IEnumerable<Statement> AttachToTrain { get; }
         public IEnumerable<Statement> Detach { get; }
 
         private StatementSet(IEnumerable<Statement> setTrack,
-            IEnumerable<Statement> accelerateFromHere, IEnumerable<Statement> accelerateToHere, IEnumerable<Statement> stopUntil,
+            IEnumerable<Statement> accelerateFromHere, IEnumerable<Statement> accelerateToHere, IEnumerable<Statement> accelerateToHereAt, 
+            IEnumerable<Statement> stopUntil,IEnumerable<Statement> stopAtUntil,IEnumerable<Statement> stopAt,
             IEnumerable<Statement> attachToTrain, IEnumerable<Statement> detach)
         {
             SetTrack = setTrack;
             AccelerateFromHere = accelerateFromHere;
             AccelerateToHere = accelerateToHere;
+            AccelerateToHereAt = accelerateToHereAt;
             StopUntil = stopUntil;
+            StopAtUntil = stopAtUntil;
+            StopAt = stopAt;
             AttachToTrain = attachToTrain;
             Detach = detach;
         }
@@ -41,11 +48,14 @@ namespace Automatic9045.BveEx.ExtendedTrainScheduler
             IEnumerable<Statement> setTrack = source.FindUserStatements(UserName, Root, Train, ClauseFilter.Function("SetTrack", 1));
             IEnumerable<Statement> accelerateFromHere = source.FindUserStatements(UserName, Root, Train, Accelerate, ClauseFilter.Function("FromHere", 2));
             IEnumerable<Statement> accelerateToHere = source.FindUserStatements(UserName, Root, Train, Accelerate, ClauseFilter.Function("ToHere", 2));
+            IEnumerable<Statement> accelerateToHereAt = source.FindUserStatements(UserName, Root, Train, Accelerate, ClauseFilter.Function("ToHereAt", 2));
             IEnumerable<Statement> stopUntil = source.FindUserStatements(UserName, Root, Train, ClauseFilter.Function("StopUntil", 4));
+            IEnumerable<Statement> stopAtUntil = source.FindUserStatements(UserName, Root, Train, ClauseFilter.Function("StopAtUntil", 4));
+            IEnumerable<Statement> stopAt = source.FindUserStatements(UserName, Root, Train, ClauseFilter.Function("StopAt", 4));
             IEnumerable<Statement> attachToTrain = source.FindUserStatements(UserName, Root, PreTrain, ClauseFilter.Function("AttachToTrain", 1));
             IEnumerable<Statement> detach = source.FindUserStatements(UserName, Root, PreTrain, ClauseFilter.Function("Detach", 0));
 
-            return new StatementSet(setTrack, accelerateFromHere, accelerateToHere, stopUntil, attachToTrain, detach);
+            return new StatementSet(setTrack, accelerateFromHere, accelerateToHere,  accelerateToHereAt, stopUntil,stopAtUntil,stopAt, attachToTrain, detach);
         }
     }
 }

--- a/Automatic9045.BveEx.ExtendedTrainScheduler/packages.config
+++ b/Automatic9045.BveEx.ExtendedTrainScheduler/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BveEx.CoreExtensions" version="2.0.0" targetFramework="net48" />
-  <package id="BveEx.PluginHost" version="2.0.5" targetFramework="net48" />
+  <package id="BveEx.PluginHost" version="2.0.5.1" targetFramework="net48" />
   <package id="Lib.Harmony" version="2.3.5" targetFramework="net48" />
   <package id="ObjectiveHarmonyPatch" version="1.2.0" targetFramework="net48" />
   <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />

--- a/README.md
+++ b/README.md
@@ -1,13 +1,36 @@
 # BveEx.Plugins.ExtendedTrainScheduler
-【BVE/BveEX】他列車の走行スケジュールをより細かく設定できるようにするプラグインです。
+【BVE/BveEX】公式の他列車走行スケジュール拡張プラグインを改造し停車時刻から減速度を自動計算できるようにしたプラグインです
 
-詳しくは [BveEX 公式ホームページ](https://www.okaoka-depot.com/AtsEX.Docs/plugins/extended-train-scheduler/) をご覧ください。
+追加した構文についての解説です.
+他列車走行スケジュール拡張プラグイン-各構文の解説の項を参考に執筆しました.
+
+以下、「～.XXX」は全て「BveEx.User.Toukaitetudou.ExtendedTrainScheduler.XXX」を表すものとします。
+
+`～.Train[trainKey].Accelerate.ToHereAt(t, a);`
+
+目標速度 v [km/h] の加減速を、時刻 t にその距離程 “まで” で完了するように行います。
+
+`～.Train[trainKey].StopAtUntil( t1, t2, a, v);`
+
+減速し、時刻 t1 にその距離程に停車します。時刻 t2 になると発車し、加速度 a [km/h/s] で速度 v [km/h] まで加速します。
+時刻 t1, t2 の指定方法はBVE標準のTrain.Enable構文と同様です。時刻を表す文字列 'hh:mm:ss' または 00:00:00 からの経過時間 [s] で指定してください。
+
+`～.Train[trainKey].StopAt( t, st, a, v0);`
+
+減速し、時刻 t1 にその距離程に停車します。st [s] 経過すると発車し、加速度 a [km/h/s] で速度 v [km/h] まで加速します。
+時刻 t の指定方法はBVE標準のTrain.Enable構文と同様です。時刻を表す文字列 'hh:mm:ss' または 00:00:00 からの経過時間 [s] で指定してください。
+
+従来の他列車走行スケジュール拡張プラグインについては [BveEX 公式ホームページ](https://www.okaoka-depot.com/AtsEX.Docs/plugins/extended-train-scheduler/) 等をご覧ください。
 
 ## ライセンス
 
 [PolyForm Noncommercial License 1.0.0](LICENSE.md)
 
-このライセンスにおいて禁止されている方法での利用（商用利用のうち、一部のケースなど）をご希望の場合は、個別にお問い合わせください。
+## 改造元プラグイン
+
+[他列車走行スケジュール拡張プラグイン](https://github.com/automatic9045/BveEx.Plugins.ExtendedTrainScheduler)
+
+Copyright © 2024 automatic9045
 
 ## 使用ライブラリ等
 ### [BveEx.CoreExtensions](https://github.com/automatic9045/BveEX) (PolyForm NonCommercial 1.0.0)


### PR DESCRIPTION
追加した構文についての解説です.
他列車走行スケジュール拡張プラグイン-各構文の解説の項を参考に執筆しました.

以下、「～.XXX」は全て「BveEx.User.Automatic9045.ExtendedTrainScheduler.XXX」を表すものとします。
`～.Train[trainKey].Accelerate.ToHereAt(t, a);`
目標速度 v [km/h] の加減速を、時刻 t にその距離程 “まで” で完了するように行います。
`～.Train[trainKey].StopAtUntil( t1, t2, a, v);`
減速し、時刻 t1 にその距離程に停車します。時刻 t2 になると発車し、加速度 a [km/h/s] で速度 v [km/h] まで加速します。
時刻 t1, t2 の指定方法はBVE標準のTrain.Enable構文と同様です。時刻を表す文字列 'hh:mm:ss' または 00:00:00 からの経過時間 [s] で指定してください。
`～.Train[trainKey].StopAt( t, st, a, v0);`
減速し、時刻 t1 にその距離程に停車します。st [s] 経過すると発車し、加速度 a [km/h/s] で速度 v [km/h] まで加速します。
時刻 t の指定方法はBVE標準のTrain.Enable構文と同様です。時刻を表す文字列 'hh:mm:ss' または 00:00:00 からの経過時間 [s] で指定してください。